### PR TITLE
Replace extends with config computed from nested extends

### DIFF
--- a/lib/.eslintrc.js
+++ b/lib/.eslintrc.js
@@ -1,0 +1,4 @@
+// TODO Part of the bazooka CLIEngine shareable config hack. Remove once this is over.
+module.exports = {
+    extends: 'springload',
+};

--- a/lib/.eslintrc.js
+++ b/lib/.eslintrc.js
@@ -1,4 +1,0 @@
-// TODO Part of the bazooka CLIEngine shareable config hack. Remove once this is over.
-module.exports = {
-    extends: 'springload',
-};

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,35 +1,28 @@
-const path = require('path');
-// TODO Remove this since
-// const config = require('eslint-config-springload');
-const CLIEngine = require('eslint').CLIEngine;
+const { CLIEngine } = require('eslint');
 
 const { prefixConfigRules } = require('./plugins');
 
-// TODO Very heavy-handed, and likely brittle for a million reasons.
+// Very heavy-handed, and likely brittle for a million reasons.
 // This is just a test to see what happens, don't do this at home.
 const getComputedConfig = () => {
     const cli = new CLIEngine({
         useEslintrc: false,
-        // Point to a file that has the config we want to expose.
-        configFile: path.join(__dirname, '.eslintrc.js'),
+        allowInlineConfig: false,
+        baseConfig: {
+            extends: 'springload',
+        },
     });
 
-    // This does not have to point to the same file.
     return cli.getConfigForFile('.eslintrc.js');
 };
 
 const config = getComputedConfig();
 
-module.exports = {
-    parser: require.resolve('babel-eslint'),
-    // TODO extends is not necessary since we now expose a config computed from the whole extends chain.
-    // extends: config.extends,
+module.exports = Object.assign({}, config, {
+    parser: 'babel-eslint',
+    // We expose a config already computed from the whole extends chain, so no extends here.
+    extends: [],
     plugins: ['springload'],
-    // The rules from third-party plugins need to be prefixed
-    // so they reference our plugin instead.
+    // The rules from third-party plugins need to be prefixed so they reference our plugin instead.
     rules: prefixConfigRules('springload', config.rules),
-    settings: config.settings,
-    env: config.env,
-    root: config.root,
-    parserOptions: config.parserOptions,
-};
+});

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,16 +1,35 @@
-const baseConfig = require('eslint-config-springload');
+const path = require('path');
+// TODO Remove this since
+// const config = require('eslint-config-springload');
+const CLIEngine = require('eslint').CLIEngine;
 
 const { prefixConfigRules } = require('./plugins');
 
+// TODO Very heavy-handed, and likely brittle for a million reasons.
+// This is just a test to see what happens, don't do this at home.
+const getComputedConfig = () => {
+    const cli = new CLIEngine({
+        useEslintrc: false,
+        // Point to a file that has the config we want to expose.
+        configFile: path.join(__dirname, '.eslintrc.js'),
+    });
+
+    // This does not have to point to the same file.
+    return cli.getConfigForFile('.eslintrc.js');
+};
+
+const config = getComputedConfig();
+
 module.exports = {
     parser: require.resolve('babel-eslint'),
-    extends: baseConfig.extends,
+    // TODO extends is not necessary since we now expose a config computed from the whole extends chain.
+    // extends: config.extends,
     plugins: ['springload'],
     // The rules from third-party plugins need to be prefixed
     // so they reference our plugin instead.
-    rules: prefixConfigRules('springload', baseConfig.rules),
-    settings: baseConfig.settings,
-    env: baseConfig.env,
-    root: baseConfig.root,
-    parserOptions: baseConfig.parserOptions,
+    rules: prefixConfigRules('springload', config.rules),
+    settings: config.settings,
+    env: config.env,
+    root: config.root,
+    parserOptions: config.parserOptions,
 };

--- a/lib/config.test.js
+++ b/lib/config.test.js
@@ -1,0 +1,11 @@
+const config = require('./config');
+
+/**
+ * Use this to debug the configuration.
+ */
+describe('config', () => {
+    it('log', () => {
+        // eslint-disable-next-line no-console
+        console.log(config);
+    });
+});


### PR DESCRIPTION
Replaces `extends` with config computed from nested extends with CLIEngine.

This is necessary so the plugin rewrites other plugin's configured rules in _all_ of this tree of `extends` to prefix them with `springload`.

There is a small performance overhead that I measured very quickly – on a JS codebase with ±30 files, ±2000 LOC, it takes the linting run time (`npm run lint` pointing to `eslint .`) from ±3s to ±4s.

Tested in this module only, `time node lib/index.js` goes from ±350ms without this to ±700ms with it.